### PR TITLE
v0.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# v0.0.8
+
+* upd: go-trapcheck v0.0.8
+* add: additional text tests (leading/trailing spaces, non-printable char)
+* upd: generic text cleaner method
+* add: trim leading/trailing spaces from text metric values
+* add: replace non-printable chars in text metric values
+* add: replace 'smart' quotes (with regular quotes) in text metric values
+* add: escape any embedded quotes in text metric values
+* add: non-printable char replacement to config (default '_')
+* upd: check type assertions
+* add: more tests for each metric type
+
 # v0.0.7
 
 * upd: go-trapcheck v0.0.7

--- a/counter_test.go
+++ b/counter_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2021 Circonus, Inc. <support@circonus.com>
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+package trapmetrics
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTrapMetrics_CounterIncrement(t *testing.T) {
+	tests := []struct {
+		name        string
+		metricName  string
+		wantJSON    string
+		metricTags  Tags
+		metricValue int64
+		wantErr     bool
+	}{
+		{
+			name:        "valid",
+			metricName:  "test",
+			metricValue: 1,
+			metricTags: Tags{
+				Tag{
+					Category: "foo",
+					Value:    "bar",
+				},
+			},
+			wantJSON: `"_value":1`,
+			wantErr:  false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			tm, err := New(&Config{Trap: FakeTrap{}})
+			if err != nil {
+				t.Fatalf("unable to initialize TrapMetrics for test: %s", err)
+			}
+
+			if err = tm.CounterIncrement(tt.metricName, tt.metricTags); (err != nil) != tt.wantErr {
+				t.Errorf("TrapMetrics.CounterIncrement() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			m, err := tm.CounterFetch(tt.metricName, tt.metricTags)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TrapMetrics.TextFetch() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			want := tt.metricValue
+			if val, ok := m.Samples[0]; ok {
+				if val != want {
+					t.Errorf("Invalid value want [%v]%T got [%v]%T", want, want, val, val)
+				}
+			}
+
+			if jm, err := tm.JSONMetrics(); err != nil {
+				t.Fatalf("flushing metrics: %s", err)
+			} else if !strings.Contains(string(jm), tt.wantJSON) {
+				t.Errorf("json metrics want [%v] got [%v]", tt.wantJSON, string(jm))
+			}
+
+		})
+	}
+}

--- a/gauge.go
+++ b/gauge.go
@@ -101,15 +101,35 @@ func (tm *TrapMetrics) GaugeAdd(name string, tags Tags, val interface{}, ts *tim
 func addValByType(rtype string, base interface{}, val interface{}) interface{} {
 	switch rtype {
 	case rtInt32:
-		return base.(int32) + val.(int32)
+		if i, oki := base.(int32); oki {
+			if j, okj := val.(int32); okj {
+				return i + j
+			}
+		}
 	case rtInt64:
-		return base.(int64) + val.(int64)
+		if i, oki := base.(int64); oki {
+			if j, okj := val.(int64); okj {
+				return i + j
+			}
+		}
 	case rtUint32:
-		return base.(uint32) + val.(uint32)
+		if i, oki := base.(uint32); oki {
+			if j, okj := val.(uint32); okj {
+				return i + j
+			}
+		}
 	case rtUint64:
-		return base.(uint64) + val.(uint64)
+		if i, oki := base.(uint64); oki {
+			if j, okj := val.(uint64); okj {
+				return i + j
+			}
+		}
 	case rtFloat64:
-		return base.(float64) + val.(float64)
+		if i, oki := base.(float64); oki {
+			if j, okj := val.(float64); okj {
+				return i + j
+			}
+		}
 	}
 
 	return base

--- a/gauge_test.go
+++ b/gauge_test.go
@@ -1,0 +1,198 @@
+// Copyright (c) 2021 Circonus, Inc. <support@circonus.com>
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+package trapmetrics
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTrapMetrics_GaugeSet(t *testing.T) {
+	tests := []struct {
+		metricValue interface{}
+		name        string
+		metricName  string
+		wantJSON    string
+		metricTags  Tags
+		wantErr     bool
+	}{
+		{
+			name:        "valid",
+			metricName:  "test",
+			metricValue: int64(1),
+			metricTags: Tags{
+				Tag{
+					Category: "foo",
+					Value:    "bar",
+				},
+			},
+			wantJSON: `"_value":1`,
+			wantErr:  false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			tm, err := New(&Config{Trap: FakeTrap{}})
+			if err != nil {
+				t.Fatalf("unable to initialize TrapMetrics for test: %s", err)
+			}
+
+			ts := time.Now()
+
+			if err = tm.GaugeSet(tt.metricName, tt.metricTags, tt.metricValue, &ts); (err != nil) != tt.wantErr {
+				t.Errorf("TrapMetrics.GaugeSet() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			m, err := tm.GaugeFetch(tt.metricName, tt.metricTags)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TrapMetrics.TextFetch() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			want := tt.metricValue
+			sk := generateSampleKey(&ts)
+			if val, ok := m.Samples[sk]; ok {
+				if val != want {
+					t.Errorf("Invalid value want [%v]%T got [%v]%T", want, want, val, val)
+				}
+			} else {
+				t.Fatalf("unable to get sample for key %v", sk)
+			}
+
+			if jm, err := tm.JSONMetrics(); err != nil {
+				t.Fatalf("flushing metrics: %s", err)
+			} else if !strings.Contains(string(jm), tt.wantJSON) {
+				t.Errorf("json metrics want [%v] got [%v]", tt.wantJSON, string(jm))
+			}
+		})
+	}
+}
+
+func TestTrapMetrics_GaugeAdd(t *testing.T) {
+	tests := []struct {
+		metricValue interface{}
+		wantValue   interface{}
+		name        string
+		metricName  string
+		wantJSON    string
+		metricTags  Tags
+		wantErr     bool
+	}{
+		{
+			name:        "valid int32",
+			metricName:  "test",
+			metricValue: int32(1),
+			metricTags: Tags{
+				Tag{
+					Category: "foo",
+					Value:    "bar",
+				},
+			},
+			wantJSON:  `"_value":2`,
+			wantValue: int32(2),
+			wantErr:   false,
+		},
+		{
+			name:        "valid int64",
+			metricName:  "test",
+			metricValue: int64(1),
+			metricTags: Tags{
+				Tag{
+					Category: "foo",
+					Value:    "bar",
+				},
+			},
+			wantJSON:  `"_value":2`,
+			wantValue: int64(2),
+			wantErr:   false,
+		},
+		{
+			name:        "valid uint32",
+			metricName:  "test",
+			metricValue: uint32(1),
+			metricTags: Tags{
+				Tag{
+					Category: "foo",
+					Value:    "bar",
+				},
+			},
+			wantJSON:  `"_value":2`,
+			wantValue: uint32(2),
+			wantErr:   false,
+		},
+		{
+			name:        "valid uint64",
+			metricName:  "test",
+			metricValue: uint64(1),
+			metricTags: Tags{
+				Tag{
+					Category: "foo",
+					Value:    "bar",
+				},
+			},
+			wantJSON:  `"_value":2`,
+			wantValue: uint64(2),
+			wantErr:   false,
+		},
+		{
+			name:        "valid float64",
+			metricName:  "test",
+			metricValue: float64(1.2),
+			metricTags: Tags{
+				Tag{
+					Category: "foo",
+					Value:    "bar",
+				},
+			},
+			wantJSON:  `"_value":2.4`,
+			wantValue: float64(2.4),
+			wantErr:   false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			tm, err := New(&Config{Trap: FakeTrap{}})
+			if err != nil {
+				t.Fatalf("unable to initialize TrapMetrics for test: %s", err)
+			}
+
+			ts := time.Now()
+
+			if err = tm.GaugeAdd(tt.metricName, tt.metricTags, tt.metricValue, &ts); (err != nil) != tt.wantErr {
+				t.Errorf("TrapMetrics.GaugeSet() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if err = tm.GaugeAdd(tt.metricName, tt.metricTags, tt.metricValue, &ts); (err != nil) != tt.wantErr {
+				t.Errorf("TrapMetrics.GaugeAdd() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			m, err := tm.GaugeFetch(tt.metricName, tt.metricTags)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TrapMetrics.TextFetch() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			want := tt.wantValue
+			sk := generateSampleKey(&ts)
+			if val, ok := m.Samples[sk]; ok {
+				if val != want {
+					t.Errorf("Invalid value want [%v]%T got [%v]%T", want, want, val, val)
+				}
+			} else {
+				t.Fatalf("unable to get sample for key %v", sk)
+			}
+
+			if jm, err := tm.JSONMetrics(); err != nil {
+				t.Fatalf("flushing metrics: %s", err)
+			} else if !strings.Contains(string(jm), tt.wantJSON) {
+				t.Errorf("json metrics want [%v] got [%v]", tt.wantJSON, string(jm))
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/circonus-labs/go-trapmetrics
 go 1.15
 
 require (
-	github.com/circonus-labs/go-trapcheck v0.0.7
+	github.com/circonus-labs/go-trapcheck v0.0.8
 	github.com/openhistogram/circonusllhist v0.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/circonus-labs/go-apiclient v0.7.15 h1:r9sUdc+EDM0tL6Z6u03dac8fxYvlz1kPhxlNwkoIoqM=
 github.com/circonus-labs/go-apiclient v0.7.15/go.mod h1:RFgkvdYEkimzgu3V2vVYlS1bitjOz1SF6uw109ieNeY=
-github.com/circonus-labs/go-trapcheck v0.0.7 h1:aNofUdDtGwQXPcd+43oq3zZRkRhZ7MGqvvuQE52NoiQ=
-github.com/circonus-labs/go-trapcheck v0.0.7/go.mod h1:j7vCtb3MfxGZnLCZBdpl0ZGDSGuGbbGRx9rFyGl6OAo=
+github.com/circonus-labs/go-trapcheck v0.0.8 h1:5i4GPlKKZWpfG/0p9ggbGZfjaiHkDQnjIB6DwJKDrJE=
+github.com/circonus-labs/go-trapcheck v0.0.8/go.mod h1:j7vCtb3MfxGZnLCZBdpl0ZGDSGuGbbGRx9rFyGl6OAo=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2021 Circonus, Inc. <support@circonus.com>
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+package trapmetrics
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTrapMetrics_HistogramRecordValue(t *testing.T) {
+	tests := []struct {
+		name        string
+		metricName  string
+		wantJSON    string
+		metricTags  Tags
+		metricValue float64
+		wantErr     bool
+	}{
+		{
+			name:        "valid",
+			metricName:  "test",
+			metricValue: 3.14,
+			metricTags: Tags{
+				Tag{
+					Category: "foo",
+					Value:    "bar",
+				},
+			},
+			wantJSON: `"_value":"AAEfAAAB"`,
+			wantErr:  false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			tm, err := New(&Config{Trap: FakeTrap{}})
+			if err != nil {
+				t.Fatalf("unable to initialize TrapMetrics for test: %s", err)
+			}
+
+			if err = tm.HistogramRecordValue(tt.metricName, tt.metricTags, tt.metricValue); (err != nil) != tt.wantErr {
+				t.Errorf("TrapMetrics.HistogramRecordValue() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if jm, err := tm.JSONMetrics(); err != nil {
+				t.Fatalf("flushing metrics: %s", err)
+			} else if !strings.Contains(string(jm), tt.wantJSON) {
+				t.Errorf("json metrics want [%v] got [%v]", tt.wantJSON, string(jm))
+			}
+		})
+	}
+}
+
+func TestTrapMetrics_HistogramRecordDuration(t *testing.T) {
+	tests := []struct {
+		name        string
+		metricName  string
+		wantJSON    string
+		metricTags  Tags
+		metricValue time.Duration
+		wantErr     bool
+	}{
+		{
+			name:        "valid",
+			metricName:  "test",
+			metricValue: 3 * time.Millisecond,
+			metricTags: Tags{
+				Tag{
+					Category: "foo",
+					Value:    "bar",
+				},
+			},
+			wantJSON: `"_value":"AAEe/QAB"`,
+			wantErr:  false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			tm, err := New(&Config{Trap: FakeTrap{}})
+			if err != nil {
+				t.Fatalf("unable to initialize TrapMetrics for test: %s", err)
+			}
+
+			if err := tm.HistogramRecordDuration(tt.metricName, tt.metricTags, tt.metricValue); (err != nil) != tt.wantErr {
+				t.Errorf("TrapMetrics.HistogramRecordDuration() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if jm, err := tm.JSONMetrics(); err != nil {
+				t.Fatalf("flushing metrics: %s", err)
+			} else if !strings.Contains(string(jm), tt.wantJSON) {
+				t.Errorf("json metrics want [%v] got [%v]", tt.wantJSON, string(jm))
+			}
+		})
+	}
+}
+
+func TestTrapMetrics_HistogramRecordCountForValue(t *testing.T) {
+	tests := []struct {
+		name        string
+		metricName  string
+		wantJSON    string
+		metricTags  Tags
+		metricValue float64
+		metricCount int64
+		wantErr     bool
+	}{
+		{
+			name:        "valid",
+			metricName:  "test",
+			metricValue: 6.2,
+			metricCount: 7,
+			metricTags: Tags{
+				Tag{
+					Category: "foo",
+					Value:    "bar",
+				},
+			},
+			wantJSON: `"_value":"AAE+AAAH"`,
+			wantErr:  false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			tm, err := New(&Config{Trap: FakeTrap{}})
+			if err != nil {
+				t.Fatalf("unable to initialize TrapMetrics for test: %s", err)
+			}
+
+			if err := tm.HistogramRecordCountForValue(tt.metricName, tt.metricTags, tt.metricCount, tt.metricValue); (err != nil) != tt.wantErr {
+				t.Errorf("TrapMetrics.HistogramRecordCountForValue() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if jm, err := tm.JSONMetrics(); err != nil {
+				t.Fatalf("flushing metrics: %s", err)
+			} else if !strings.Contains(string(jm), tt.wantJSON) {
+				t.Errorf("json metrics want [%v] got [%v]", tt.wantJSON, string(jm))
+			}
+		})
+	}
+}

--- a/histogram_util.go
+++ b/histogram_util.go
@@ -25,7 +25,9 @@ func (tm *TrapMetrics) setValue(name string, tags Tags, cumulative bool, val flo
 		return err
 	}
 
-	_ = m.Samples[0].(*circonusllhist.Histogram).RecordValue(val)
+	if s, ok := m.Samples[0].(*circonusllhist.Histogram); ok {
+		_ = s.RecordValue(val)
+	}
 
 	return nil
 }
@@ -39,7 +41,9 @@ func (tm *TrapMetrics) setDuration(name string, tags Tags, cumulative bool, val 
 		return err
 	}
 
-	_ = m.Samples[0].(*circonusllhist.Histogram).RecordDuration(val)
+	if s, ok := m.Samples[0].(*circonusllhist.Histogram); ok {
+		_ = s.RecordDuration(val)
+	}
 
 	return nil
 }
@@ -53,7 +57,9 @@ func (tm *TrapMetrics) setCountForValue(name string, tags Tags, cumulative bool,
 		return err
 	}
 
-	_ = m.Samples[0].(*circonusllhist.Histogram).RecordValues(val, count)
+	if s, ok := m.Samples[0].(*circonusllhist.Histogram); ok {
+		_ = s.RecordValues(val, count)
+	}
 
 	return nil
 }

--- a/text.go
+++ b/text.go
@@ -25,22 +25,13 @@ func (tm *TrapMetrics) TextSet(name string, tags Tags, val string, ts *time.Time
 	tm.metricsmu.Lock()
 	defer tm.metricsmu.Unlock()
 
-	// remove leading and trailing spaces
-	val = strings.TrimSpace(val)
-
-	// replace any non-printable characters with
-	val = strings.Map(func(r rune) rune {
-		if unicode.IsPrint(r) {
-			return r
-		}
-		return tm.nonPrintCharReplace
-	}, val)
+	value := tm.cleanTextValue(val)
 
 	if m, ok := tm.metrics[metricID]; ok {
 		if m.Mtype != mtText {
 			return fmt.Errorf("(%s %s) exists with different type (text) vs (%s)", name, tags.String(), m.Mtype)
 		}
-		m.Samples[sampleKey] = val
+		m.Samples[sampleKey] = value
 		return nil
 	}
 
@@ -49,7 +40,7 @@ func (tm *TrapMetrics) TextSet(name string, tags Tags, val string, ts *time.Time
 		return fmt.Errorf("(%s %s) failed to initialize (text): %w", name, tags.String(), err)
 	}
 	m.Rtype = rtString
-	m.Samples[sampleKey] = val
+	m.Samples[sampleKey] = value
 
 	tm.metrics[m.ID] = m
 
@@ -71,4 +62,19 @@ func (tm *TrapMetrics) TextFetch(name string, tags Tags) (*Metric, error) {
 	}
 
 	return nil, fmt.Errorf("text %d (%s %s) not found", metricID, name, tags.String())
+}
+
+func (tm *TrapMetrics) cleanTextValue(val string) string {
+	// remove leading and trailing spaces
+	clean := strings.TrimSpace(val)
+
+	// replace any non-printable characters with
+	clean = strings.Map(func(r rune) rune {
+		if unicode.IsPrint(r) {
+			return r
+		}
+		return tm.nonPrintCharReplace
+	}, clean)
+
+	return clean
 }

--- a/text.go
+++ b/text.go
@@ -7,7 +7,9 @@ package trapmetrics
 
 import (
 	"fmt"
+	"strings"
 	"time"
+	"unicode"
 )
 
 // TextSet sets a sample with a given timestamp for a text to the passed value.
@@ -22,6 +24,17 @@ func (tm *TrapMetrics) TextSet(name string, tags Tags, val string, ts *time.Time
 
 	tm.metricsmu.Lock()
 	defer tm.metricsmu.Unlock()
+
+	// remove leading and trailing spaces
+	val = strings.TrimSpace(val)
+
+	// replace any non-printable characters with
+	val = strings.Map(func(r rune) rune {
+		if unicode.IsPrint(r) {
+			return r
+		}
+		return tm.nonPrintCharReplace
+	}, val)
 
 	if m, ok := tm.metrics[metricID]; ok {
 		if m.Mtype != mtText {

--- a/text.go
+++ b/text.go
@@ -68,7 +68,7 @@ func (tm *TrapMetrics) cleanTextValue(val string) string {
 	// remove leading and trailing spaces
 	clean := strings.TrimSpace(val)
 
-	// replace any non-printable characters with
+	// replace any non-printable characters with configured tm.nonPrintCharReplace
 	clean = strings.Map(func(r rune) rune {
 		if unicode.IsPrint(r) {
 			return r

--- a/text_test.go
+++ b/text_test.go
@@ -34,6 +34,45 @@ func TestTrapMetrics_TextSet(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name:        "valid w/leading spaces",
+			metricName:  "test",
+			metricValue: "  test",
+			metricTags: Tags{
+				Tag{
+					Category: "foo",
+					Value:    "bar",
+				},
+			},
+			wantJSON: `"_value":"test"`,
+			wantErr:  false,
+		},
+		{
+			name:        "valid w/trailing spaces",
+			metricName:  "test",
+			metricValue: "test  ",
+			metricTags: Tags{
+				Tag{
+					Category: "foo",
+					Value:    "bar",
+				},
+			},
+			wantJSON: `"_value":"test"`,
+			wantErr:  false,
+		},
+		{
+			name:        "valid w/non-printable char",
+			metricName:  "test",
+			metricValue: "test\x07",
+			metricTags: Tags{
+				Tag{
+					Category: "foo",
+					Value:    "bar",
+				},
+			},
+			wantJSON: `"_value":"test_"`,
+			wantErr:  false,
+		},
+		{
 			name:        "valid w/embedded double quotes",
 			metricName:  "test",
 			metricValue: `test "test"`,
@@ -105,7 +144,7 @@ func TestTrapMetrics_TextSet(t *testing.T) {
 				t.Errorf("TrapMetrics.TextFetch() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
-			want := tt.metricValue
+			want := tm.cleanTextValue(tt.metricValue)
 			sk := generateSampleKey(&ts)
 			if val, ok := m.Samples[sk]; ok {
 				if val != want {

--- a/text_test.go
+++ b/text_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2021 Circonus, Inc. <support@circonus.com>
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+package trapmetrics
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTrapMetrics_TextSet(t *testing.T) {
+	tests := []struct {
+		name        string
+		wantJSON    string
+		metricName  string
+		metricValue string
+		metricTags  Tags
+		wantErr     bool
+	}{
+		{
+			name:        "valid",
+			metricName:  "test",
+			metricValue: "test",
+			metricTags: Tags{
+				Tag{
+					Category: "foo",
+					Value:    "bar",
+				},
+			},
+			wantJSON: `"_value":"test"`,
+			wantErr:  false,
+		},
+		{
+			name:        "valid w/embedded double quotes",
+			metricName:  "test",
+			metricValue: `test "test"`,
+			metricTags: Tags{
+				Tag{
+					Category: "foo",
+					Value:    "bar",
+				},
+			},
+			wantJSON: `"_value":"test \"test\""`,
+			wantErr:  false,
+		},
+		{
+			name:        "valid w/embedded single quotes",
+			metricName:  "test",
+			metricValue: `test 'test'`,
+			metricTags: Tags{
+				Tag{
+					Category: "foo",
+					Value:    "bar",
+				},
+			},
+			wantJSON: `"_value":"test 'test'"`,
+			wantErr:  false,
+		},
+		{
+			name:        "valid w/embedded 'smart' double quotes",
+			metricName:  "test",
+			metricValue: `test “smart”`,
+			metricTags: Tags{
+				Tag{
+					Category: "foo",
+					Value:    "bar",
+				},
+			},
+			wantJSON: `"_value":"test \"smart\""`,
+			wantErr:  false,
+		},
+		{
+			name:        "valid w/embedded 'smart' single quotes",
+			metricName:  "test",
+			metricValue: `test ‘smart’`,
+			metricTags: Tags{
+				Tag{
+					Category: "foo",
+					Value:    "bar",
+				},
+			},
+			wantJSON: `"_value":"test 'smart'"`,
+			wantErr:  false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			tm, err := New(&Config{Trap: FakeTrap{}})
+			if err != nil {
+				t.Fatalf("unable to initialize TrapMetrics for test: %s", err)
+			}
+
+			ts := time.Now()
+
+			if err = tm.TextSet(tt.metricName, tt.metricTags, tt.metricValue, &ts); (err != nil) != tt.wantErr {
+				t.Errorf("TrapMetrics.TextSet() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			m, err := tm.TextFetch(tt.metricName, tt.metricTags)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TrapMetrics.TextFetch() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			want := tt.metricValue
+			sk := generateSampleKey(&ts)
+			if val, ok := m.Samples[sk]; ok {
+				if val != want {
+					t.Errorf("Invalid value want [%v]%T got [%v]%T", want, want, val, val)
+				}
+			} else {
+				t.Fatalf("unable to get sample for key %v", sk)
+			}
+
+			if jm, err := tm.JSONMetrics(); err != nil {
+				t.Fatalf("flushing metrics: %s", err)
+			} else if !strings.Contains(string(jm), tt.wantJSON) {
+				t.Errorf("json metrics want [%v] got [%v]", tt.wantJSON, string(jm))
+			}
+		})
+	}
+}

--- a/trapmetrics_test.go
+++ b/trapmetrics_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2021 Circonus, Inc. <support@circonus.com>
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+package trapmetrics
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/circonus-labs/go-trapcheck"
+)
+
+type FakeTrap struct {
+}
+
+func (ft FakeTrap) SendMetrics(ctx context.Context, metrics bytes.Buffer) (*trapcheck.TrapResult, error) {
+	fmt.Println(metrics)
+	return nil, nil
+}
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		cfg     *Config
+		name    string
+		wantErr bool
+	}{
+		{
+			name:    "invalid",
+			cfg:     nil,
+			wantErr: true,
+		},
+		{
+			name: "valid",
+			cfg: &Config{
+				Trap: FakeTrap{},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := New(tt.cfg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
* upd: go-trapcheck v0.0.8
* add: additional text tests (leading/trailing spaces, non-printable char)
* upd: generic text cleaner method
* add: trim leading/trailing spaces from text metric values
* add: replace non-printable chars in text metric values
* add: replace 'smart' quotes (with regular quotes) in text metric values
* add: escape any embedded quotes in text metric values
* add: non-printable char replacement to config (default '_')
* upd: check type assertions
* add: more tests for each metric type
