### PR TITLE
v0.0.9 [CIRC-8780]

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,11 +14,11 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           stable: true
-          go-version: 1.16.x
+          go-version: 1.17.x
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.1.0
         with:
-          version: v1.42
+          version: v1.48
           skip-go-installation: true
           args: --timeout=5m

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v0.0.9
+
+* feat: add `UpdateCheckTags` method
+* feat: add `QueueCheckTag` method
+* feat(deps): bump go-apiclient from 0.7.15 to 0.7.18
+* feat(deps): bump go-trapcheck from 0.0.8 to 0.0.9
+* chore: update to go1.17
+* fix(lint): ioutil deprecation
+
 # v0.0.8
 
 * upd: go-trapcheck v0.0.8

--- a/check_tags.go
+++ b/check_tags.go
@@ -1,0 +1,42 @@
+package trapmetrics
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/circonus-labs/go-apiclient"
+)
+
+func (tm *TrapMetrics) QueueCheckTag(key, val string) {
+	if key != "" && val != "" {
+		tm.checkTags[key] = val
+	}
+}
+
+func (tm *TrapMetrics) UpdateCheckTags(ctx context.Context) (*apiclient.CheckBundle, error) {
+	if len(tm.checkTags) == 0 {
+		return nil, nil
+	}
+
+	tags := make([]string, 0, len(tm.checkTags))
+	for k, v := range tm.checkTags {
+		tags = append(tags, k+":"+v)
+	}
+
+	b, err := tm.trap.UpdateCheckTags(ctx, tags)
+
+	// reset the tags
+	tm.checkTags = make(map[string]string)
+
+	if err != nil {
+		return nil, fmt.Errorf("updating check tags: %w", err)
+	}
+
+	if b != nil {
+		// if we got a bundle back, tags were updated
+		// return it so it can be saved in the cache
+		return b, nil
+	}
+
+	return nil, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,18 @@
 module github.com/circonus-labs/go-trapmetrics
 
-go 1.15
+go 1.17
+
+replace github.com/circonus-labs/go-trapcheck => ../go-trapcheck
 
 require (
+	github.com/circonus-labs/go-apiclient v0.7.15
 	github.com/circonus-labs/go-trapcheck v0.0.8
 	github.com/openhistogram/circonusllhist v0.3.0
+)
+
+require (
+	github.com/google/uuid v1.3.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -2,17 +2,15 @@ module github.com/circonus-labs/go-trapmetrics
 
 go 1.17
 
-replace github.com/circonus-labs/go-trapcheck => ../go-trapcheck
-
 require (
-	github.com/circonus-labs/go-apiclient v0.7.15
-	github.com/circonus-labs/go-trapcheck v0.0.8
+	github.com/circonus-labs/go-apiclient v0.7.18
+	github.com/circonus-labs/go-trapcheck v0.0.9
 	github.com/openhistogram/circonusllhist v0.3.0
 )
 
 require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.0 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,5 @@
 github.com/circonus-labs/go-apiclient v0.7.15 h1:r9sUdc+EDM0tL6Z6u03dac8fxYvlz1kPhxlNwkoIoqM=
 github.com/circonus-labs/go-apiclient v0.7.15/go.mod h1:RFgkvdYEkimzgu3V2vVYlS1bitjOz1SF6uw109ieNeY=
-github.com/circonus-labs/go-trapcheck v0.0.8 h1:5i4GPlKKZWpfG/0p9ggbGZfjaiHkDQnjIB6DwJKDrJE=
-github.com/circonus-labs/go-trapcheck v0.0.8/go.mod h1:j7vCtb3MfxGZnLCZBdpl0ZGDSGuGbbGRx9rFyGl6OAo=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -17,7 +14,5 @@ github.com/openhistogram/circonusllhist v0.3.0 h1:CuEawy94hKEzjhSABdqkGirl6o67Qr
 github.com/openhistogram/circonusllhist v0.3.0/go.mod h1:PfeYJ/RW2+Jfv3wTz0upbY2TRour/LLqIm2K2Kw5zg0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
-github.com/circonus-labs/go-apiclient v0.7.15 h1:r9sUdc+EDM0tL6Z6u03dac8fxYvlz1kPhxlNwkoIoqM=
-github.com/circonus-labs/go-apiclient v0.7.15/go.mod h1:RFgkvdYEkimzgu3V2vVYlS1bitjOz1SF6uw109ieNeY=
+github.com/circonus-labs/go-apiclient v0.7.18 h1:OrRHUwoFroEUN+3KylQkdQOaTN1s3SCFh9E6D7Eb9PQ=
+github.com/circonus-labs/go-apiclient v0.7.18/go.mod h1:NCu3kJ282ZGzr7vxzFH/S28y1nW9DZ37f8L7veDENFc=
+github.com/circonus-labs/go-trapcheck v0.0.9 h1:avgxD4QyB44sNl8IkjeA68/L8Yanl0YdwrCJdME0Qfg=
+github.com/circonus-labs/go-trapcheck v0.0.9/go.mod h1:xZpt1/2XJTmhcvW/OOGrv4zW4SHNzj4twr6tY9IkXeQ=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -7,9 +9,8 @@ github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVo
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
-github.com/hashicorp/go-retryablehttp v0.6.8/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
-github.com/hashicorp/go-retryablehttp v0.7.0 h1:eu1EI/mbirUgP5C8hVsTNaGZreBDlYiwC1FZWkvQPQ4=
-github.com/hashicorp/go-retryablehttp v0.7.0/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/hashicorp/go-retryablehttp v0.7.1 h1:sUiuQAnLlbvmExtFQs72iFW/HXeUn8Z1aJLQ4LJJbTQ=
+github.com/hashicorp/go-retryablehttp v0.7.1/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/openhistogram/circonusllhist v0.3.0 h1:CuEawy94hKEzjhSABdqkGirl6o67QrqtRoZg3CXBn6k=
 github.com/openhistogram/circonusllhist v0.3.0/go.mod h1:PfeYJ/RW2+Jfv3wTz0upbY2TRour/LLqIm2K2Kw5zg0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/trapmetrics.go
+++ b/trapmetrics.go
@@ -10,11 +10,11 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"sync"
 	"time"
 
+	"github.com/circonus-labs/go-apiclient"
 	"github.com/circonus-labs/go-trapcheck"
 )
 
@@ -25,6 +25,7 @@ const (
 // Trap defines the interface for for submitting metrics.
 type Trap interface {
 	SendMetrics(ctx context.Context, metrics bytes.Buffer) (*trapcheck.TrapResult, error)
+	UpdateCheckTags(ctx context.Context, tags []string) (*apiclient.CheckBundle, error)
 }
 
 type Config struct {
@@ -38,6 +39,9 @@ type Config struct {
 	// NonPrintCharReplace replacement for non-printable characters
 	NonPrintCharReplace string
 
+	// Trap ID (used for caching check bundle)
+	TrapID string
+
 	// GlobalTags is a list of tags to be added to every metric
 	GlobalTags Tags
 
@@ -49,7 +53,9 @@ type TrapMetrics struct { //nolint:govet
 	metricsmu           sync.Mutex
 	trap                Trap
 	Log                 Logger
+	checkTags           map[string]string
 	metrics             Metrics
+	trapID              string
 	globalTags          Tags
 	bufferSize          uint
 	nonPrintCharReplace rune
@@ -65,13 +71,14 @@ func New(cfg *Config) (*TrapMetrics, error) {
 		metrics:             make(Metrics),
 		globalTags:          cfg.GlobalTags,
 		nonPrintCharReplace: rune('_'),
+		checkTags:           make(map[string]string),
 	}
 
 	if cfg.Logger != nil {
 		tm.Log = cfg.Logger
 	} else {
 		tm.Log = &LogWrapper{
-			Log:   log.New(ioutil.Discard, "", log.LstdFlags),
+			Log:   log.New(io.Discard, "", log.LstdFlags),
 			Debug: false,
 		}
 	}
@@ -103,6 +110,10 @@ func (tm *TrapMetrics) JSONMetrics() ([]byte, error) {
 // of metrics from different trapmetrics containers).
 func (tm *TrapMetrics) WriteJSONMetrics(w io.Writer) error {
 	return tm.writeJSONMetrics(w)
+}
+
+func (tm *TrapMetrics) TrapID() string {
+	return tm.trapID
 }
 
 type Result struct {

--- a/trapmetrics.go
+++ b/trapmetrics.go
@@ -3,6 +3,8 @@
 // license that can be found in the LICENSE file.
 //
 
+//go:build go1.17
+
 package trapmetrics
 
 import (

--- a/trapmetrics_test.go
+++ b/trapmetrics_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/circonus-labs/go-apiclient"
 	"github.com/circonus-labs/go-trapcheck"
 )
 
@@ -19,6 +20,9 @@ type FakeTrap struct {
 
 func (ft FakeTrap) SendMetrics(ctx context.Context, metrics bytes.Buffer) (*trapcheck.TrapResult, error) {
 	fmt.Println(metrics)
+	return nil, nil
+}
+func (ft FakeTrap) UpdateCheckTags(ctx context.Context, tags []string) (*apiclient.CheckBundle, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
* feat: add `UpdateCheckTags` method
* feat: add `QueueCheckTag` method
* feat(deps): bump go-apiclient from 0.7.15 to 0.7.18
* feat(deps): bump go-trapcheck from 0.0.8 to 0.0.9
* chore: update to go1.17
* fix(lint): ioutil deprecation
